### PR TITLE
feat(contracts): migrate RPC endpoints to Sepolia and Base

### DIFF
--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,0 +1,26 @@
+# RPC URLs
+# Get free RPC URLs from Alchemy (https://alchemy.com) or Infura (https://infura.io)
+SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY
+
+# Block Explorer API Keys (for contract verification)
+# Etherscan: https://etherscan.io/myapikey
+# Basescan: https://basescan.org/myapikey
+ETHERSCAN_API_KEY=your_etherscan_api_key
+BASESCAN_API_KEY=your_basescan_api_key
+
+# Deployment
+PRIVATE_KEY=your_private_key_without_0x_prefix
+
+# Chainlink VRF (Sepolia)
+# Docs: https://docs.chain.link/vrf/v2-5/supported-networks#sepolia-testnet
+VRF_SUBSCRIPTION_ID=your_subscription_id
+VRF_COORDINATOR_SEPOLIA=0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B
+VRF_KEY_HASH_SEPOLIA=0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae
+LINK_TOKEN_SEPOLIA=0x779877A7B0D9E8603169DdbD7836e478b4624789
+
+# Chainlink VRF (Base)
+# Docs: https://docs.chain.link/vrf/v2-5/supported-networks#base-mainnet
+VRF_COORDINATOR_BASE=0xd5D517aBE5cF79B7e95eC98dB0f0277788aFF634
+VRF_KEY_HASH_BASE=0x00b81b5a526eb34fd7da96cbb5d76b90f0f0f3fd7e03bbcee260a528e01dd6be
+LINK_TOKEN_BASE=0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -2,12 +2,17 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-evm_version = "london"
+evm_version = "paris"
 
 # Network configurations
 [rpc_endpoints]
 anvil = "http://localhost:8545"
-chronos = "https://auto-evm.chronos.autonomys.xyz/ws"
-autonomys = "https://auto-evm.mainnet.autonomys.xyz/ws"
+sepolia = "${SEPOLIA_RPC_URL}"
+base = "${BASE_RPC_URL}"
+
+# Etherscan API keys for contract verification
+[etherscan]
+sepolia = { key = "${ETHERSCAN_API_KEY}" }
+base = { key = "${BASESCAN_API_KEY}", url = "https://api.basescan.org/api" }
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
This pull request updates the environment and configuration files to support deployment and verification on Sepolia and Base networks, as well as integrates Chainlink VRF settings for both networks. The changes make it easier to configure RPC endpoints, block explorer API keys, deployment credentials, and Chainlink VRF parameters for smart contract development and deployment.

**Environment and network configuration:**

* Added a new `.env.example` file with variables for Sepolia and Base RPC URLs, Etherscan and Basescan API keys, deployment private key, and Chainlink VRF settings for both Sepolia and Base networks.
* Updated `foundry.toml` to use the `paris` EVM version, added Sepolia and Base RPC endpoints referencing environment variables, and configured Etherscan and Basescan API keys for contract verification.- Replace Autonomys network endpoints (chronos, autonomys) with Sepolia and Base

Closes #5 and #10 