### PR TITLE
feat(web): improve contests page empty state

### DIFF
--- a/apps/web/src/app/contests/page.tsx
+++ b/apps/web/src/app/contests/page.tsx
@@ -3,6 +3,7 @@
 import { useContests } from '../../hooks/use-contests';
 import { ContestCard } from '../../components/contest-card';
 import { ContestCardSkeleton } from '../../components/skeleton';
+import { ContestsEmptyState } from '../../components/contests-empty-state';
 import { Nav } from '../../components/nav';
 
 export const dynamic = 'force-dynamic';
@@ -28,7 +29,7 @@ const ContestsPage = () => {
             <ContestCardSkeleton />
           </div>
         ) : contests.length === 0 ? (
-          <div className="text-center py-20 text-slate-600">No contests found</div>
+          <ContestsEmptyState />
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {contests.map((contest) => (

--- a/apps/web/src/components/contests-empty-state.tsx
+++ b/apps/web/src/components/contests-empty-state.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { IconTrophy, IconPlus, IconCrown } from './icons';
+
+export const ContestsEmptyState = () => {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4">
+      {/* Illustration */}
+      <div className="relative mb-6">
+        <div className="w-24 h-24 rounded-full bg-amber-100 flex items-center justify-center">
+          <IconTrophy className="w-12 h-12 text-amber-500" />
+        </div>
+        <div className="absolute -bottom-1 -right-1 w-8 h-8 rounded-full bg-slate-100 flex items-center justify-center ring-4 ring-white">
+          <IconCrown className="w-4 h-4 text-slate-400" />
+        </div>
+      </div>
+
+      {/* Copy */}
+      <h2 className="text-xl font-semibold text-slate-900 mb-2">No contests yet</h2>
+      <p className="text-slate-600 text-center max-w-md mb-6">
+        Contests are on-chain competitions where you race to solve puzzles first. Winners earn
+        prizes through verified smart contract payouts.
+      </p>
+
+      {/* CTAs */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-amber-500 text-white rounded-lg font-medium hover:bg-amber-600 transition-colors"
+        >
+          <IconCrown className="w-4 h-4" />
+          Practice in Sandbox
+        </Link>
+        <Link
+          href="/admin"
+          className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-white text-slate-700 rounded-lg font-medium ring-1 ring-slate-200 hover:bg-slate-50 transition-colors"
+        >
+          <IconPlus className="w-4 h-4" />
+          Create Contest
+        </Link>
+      </div>
+
+      {/* Helper text */}
+      <p className="text-sm text-slate-500 mt-4">Check back soon for upcoming contests</p>
+    </div>
+  );
+};

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -70,3 +70,42 @@ export const IconX = ({ className }: { className?: string }) => {
     </svg>
   );
 };
+
+export const IconTrophy = ({ className }: { className?: string }) => {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={classNames('w-4 h-4', className)}
+    >
+      <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
+      <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
+      <path d="M4 22h16" />
+      <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
+      <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
+      <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
+    </svg>
+  );
+};
+
+export const IconPlus = ({ className }: { className?: string }) => {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={classNames('w-4 h-4', className)}
+    >
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+};


### PR DESCRIPTION
## Summary
- Add trophy icon illustration with crown accent for visual appeal
- Add helpful copy explaining what contests are and how prizes work
- Add CTAs to practice in sandbox or create contests via admin
- Add "check back soon" helper text

## Test plan
- [ ] Navigate to /contests when no contests exist
- [ ] Verify empty state shows trophy illustration
- [ ] Verify helpful copy explains contests
- [ ] Verify "Practice in Sandbox" link navigates to home
- [ ] Verify "Create Contest" link navigates to admin

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)